### PR TITLE
fixed file path to Node.js in main.go updated go.mod to format 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM golang:latest AS builder
+# Use an appropriate base image
+FROM node:18
 
+# Set the working directory
 WORKDIR /app
 
-COPY .  .
+# Copy package.json and package-lock.json
+COPY package*.json ./
 
-RUN go build -o dockit
+# Install dependencies
+RUN npm install
 
+# Copy the Node.js project files into the container
+COPY . .
 
-FROM debian:stable-slim
-
-WORKDIR /app
-
-COPY --from=builder /app/dockit /app/
-COPY --from=builder /app/templates /app/templates
-
-CMD ["./dockit"]
+# Start the Node.js application
+CMD ["node", "app.js"]

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module dockit
 
-go 1.21.0
+go 1.23

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 // Define the supported project types and their respective template files
 var ProjectTemplates = map[string]string{
 	"Django":  "templates/django/Dockerfile.tmpl",
-	"Node.js": "templates/nodejs/Dockerfile.tmpl",
+	"Node.js": "templates/Node.js/Dockerfile.tmpl",
 	"Go":      "templates/Go/Dockerfile.tmpl",
 	"Flask":   "templates/flask/Dockerfile.tmpl",
 	"Mojo":    "templates/Mojo/Dockerfile.tmpl",


### PR DESCRIPTION
Fixed the file path to Dockerfile.tmpl for Node.js .